### PR TITLE
My GitHub login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'dotenv-rails'
 end
 
 group :development do
@@ -62,3 +63,5 @@ gem 'carrierwave'
 gem 'devise'
 gem 'devise-i18n'
 gem 'kaminari'
+gem 'omniauth'
+gem 'omniauth-github'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,12 +95,22 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.9.2)
       devise (>= 4.7.1)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     faker (2.15.1)
       i18n (>= 1.6, < 2)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.0)
     ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashie (4.1.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     i18n_generators (2.2.2)
@@ -111,6 +121,7 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
+    jwt (2.2.2)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -148,9 +159,27 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.2)
     msgpack (1.3.3)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    omniauth (1.9.1)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+    omniauth-github (1.4.0)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
+    omniauth-oauth2 (1.7.0)
+      oauth2 (~> 1.4)
+      omniauth (~> 1.9)
     orm_adapter (0.5.0)
     parallel (1.20.1)
     parser (3.0.0.0)
@@ -225,6 +254,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby-vips (2.0.17)
       ffi (~> 1.9)
+    ruby2_keywords (0.0.2)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -290,12 +320,15 @@ DEPENDENCIES
   carrierwave
   devise
   devise-i18n
+  dotenv-rails
   faker
   i18n_generators
   jbuilder (~> 2.7)
   kaminari
   letter_opener_web
   listen (~> 3.3)
+  omniauth
+  omniauth-github
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.0)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def github
+    @user = User.find_or_create_from_auth_hash(request.env['omniauth.auth'])
+
+    if @user.persisted?
+      sign_in_and_redirect @user
+      set_flash_message(:notice, :success, kind: 'GitHub')
+    else
+      redirect_to new_user_registration_url
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  protected
+
+  def update_resource(resource, params)
+    return super if params['password']&.present? || params['password_confirmation']&.present?
+
+    resource.update_without_password(params.except('current_password'))
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,8 @@ class User < ApplicationRecord
 
   validates :uid, uniqueness: { scope: :provider }
 
-  def self.find_or_create_from_auth_hash!(auth)
-    find_or_create_by!(provider: auth.provider, uid: auth.uid) do |user|
+  def self.find_or_create_from_auth_hash(auth)
+    find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|
       user.name = auth.info.name
       user.email = auth.info.email
       user.password = Devise.friendly_token

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,16 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :omniauthable
+
+  validates :uid, uniqueness: { scope: :provider }
+
+  def self.find_or_create_from_auth_hash!(auth)
+    find_or_create_by!(provider: auth.provider, uid: auth.uid) do |user|
+      user.name = auth.info.name
+      user.email = auth.info.email
+      user.password = Devise.friendly_token
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :omniauthable
 
-  validates :uid, uniqueness: { scope: :provider }
+  validates :uid, uniqueness: { scope: :provider }, if: -> { uid.present? }
 
   def self.find_or_create_from_auth_hash(auth)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -273,6 +273,8 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
 
+  config.omniauth :github, ENV['CLIENT_ID'], ENV['CLIENT_SECRET'], scope: "read:user"
+
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users, controllers: {
     omniauth_callbacks: "users/omniauth_callbacks",
+    registrations: "users/registrations"
   }
   resources :books
   resources :users, only: %i(index show)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
-  devise_for :users
+  devise_for :users, controllers: {
+    omniauth_callbacks: "users/omniauth_callbacks",
+  }
   resources :books
   resources :users, only: %i(index show)
 end

--- a/db/migrate/20210101123715_add_omniauth_to_users.rb
+++ b/db/migrate/20210101123715_add_omniauth_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddOmniauthToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/migrate/20210103034100_add_index_uid_provider_to_users.rb
+++ b/db/migrate/20210103034100_add_index_uid_provider_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexUidProviderToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_index :users, %i[provider uid], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_22_011641) do
+ActiveRecord::Schema.define(version: 2021_01_03_034100) do
 
   create_table "books", force: :cascade do |t|
     t.string "title"
@@ -33,7 +33,10 @@ ActiveRecord::Schema.define(version: 2020_11_22_011641) do
     t.string "postal_code"
     t.string "address"
     t.text "self_introduction"
+    t.string "provider"
+    t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
## 目的
- FJORD BOOT CAMP 「omniauthを使ってGitHub認証を実装する」提出物
- GitHub認証によるログインを可能にする

## やったこと
- omniauth-githubを用いて、GitHubログインを実装
  - scopeはログインに最低限必要な`{read:user}`を指定（参考：[OAuth Appのスコープ](https://docs.github.com/ja/free-pro-team@latest/developers/apps/scopes-for-oauth-apps)）
  - `uid`、`provider`の2カラムの組み合わせに対し、ユニークインデックスおよびバリデーションを付与
      （ただしGitHub認証ではないアカウントの場合、上記2カラムは設定されないため、バリデーションの対象外とする）。
- 現在のパスワードなしでプロフィールを編集可能に
  - パスワード以外の変更時に現在のパスワードが設定されていても、正しく更新可能
  - パスワード及びパスワード（確認用）のいずれかが設定されている場合は、変更前同様に現在のパスワードを要求する

## 申し送り事項
- クライアントID(`CLIENTY_ID`)およびクライアントシークレット(`CLIENT_SECRET`)は`.env`で管理（dotenv-railsを使用）
- Rubocop実行済
<img src="https://user-images.githubusercontent.com/61409641/103501536-d2469e80-4e91-11eb-8e42-20a199bbd741.png" width=500>