### PR TITLE
My user icon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,5 @@ gem 'kaminari'
 
 gem 'omniauth'
 gem 'omniauth-github'
+
+gem 'active_storage_validations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,6 +321,7 @@ DEPENDENCIES
   dotenv-rails
   faker
   i18n_generators
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari
   letter_opener_web

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_storage_validations (0.9.1)
+      rails (>= 5.2.0)
     activejob (6.1.0)
       activesupport (= 6.1.0)
       globalid (>= 0.3.6)
@@ -312,6 +314,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_storage_validations
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    keys = %i[name postal_code address self_introduction]
+    keys = %i[name postal_code address self_introduction icon]
     devise_parameter_sanitizer.permit(:sign_up, keys: keys)
     devise_parameter_sanitizer.permit(:account_update, keys: keys)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  has_one_attached :icon
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[github]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
          :omniauthable, omniauth_providers: %i[github]
 
   validates :uid, uniqueness: { scope: :provider }, if: -> { uid.present? }
+  validates :icon, content_type: %i[png jpg jpeg gif]
 
   def self.from_omniauth(auth)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -17,3 +17,8 @@
   <%= f.label :self_introduction %>
   <%= f.text_area :self_introduction %>
 </div>
+
+<div class="field">
+  <%= f.label :icon %>
+  <%= f.file_field :icon %>
+</div>

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -20,5 +20,6 @@
 
 <div class="field">
   <%= f.label :icon %>
+  <%= image_tag current_user.icon.variant(resize_to_limit: [50, 50]) if current_user.icon.attached? %><br />
   <%= f.file_field :icon %>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -7,6 +7,7 @@
       <th><%= User.human_attribute_name(:name) %></th>
       <th><%= User.human_attribute_name(:postal_code) %></th>
       <th><%= User.human_attribute_name(:address) %></th>
+      <th><%= User.human_attribute_name(:icon) %></th>
       <th></th>
     </tr>
   </thead>
@@ -18,6 +19,7 @@
         <td><%= user.name %></td>
         <td><%= user.postal_code %></td>
         <td><%= user.address %></td>
+        <td><%= image_tag user.icon if user.icon.attached? %></td>
         <td><%= link_to t('views.common.show'), user %></td>
       </tr>
     <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -19,7 +19,7 @@
         <td><%= user.name %></td>
         <td><%= user.postal_code %></td>
         <td><%= user.address %></td>
-        <td><%= image_tag user.icon if user.icon.attached? %></td>
+        <td><%= image_tag user.icon.variant(resize_to_limit: [30, 30]) if user.icon.attached? %></td>
         <td><%= link_to t('views.common.show'), user %></td>
       </tr>
     <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,6 +25,11 @@
   <%= @user.self_introduction %>
 </p>
 
+<p>
+  <strong><%= User.human_attribute_name(:icon) %>:</strong>
+  <%= image_tag @user.icon if @user.icon.attached? %>
+</p>
+
 <% if current_user == @user %>
   <%= link_to t('views.common.edit'), edit_user_registration_path %> |
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,7 @@
 
 <p>
   <strong><%= User.human_attribute_name(:icon) %>:</strong>
-  <%= image_tag @user.icon if @user.icon.attached? %>
+  <%= image_tag @user.icon.variant(resize_to_limit: [50, 50]) if @user.icon.attached? %>
 </p>
 
 <% if current_user == @user %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,7 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+        content_type_invalid: "には、JPG、PNG、GIFのいずれかを指定してください"
   date:
     abbr_day_names:
     - 日

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -14,3 +14,4 @@ ja:
         postal_code: 郵便番号
         address: 住所
         self_introduction: 自己紹介文
+        icon: アイコン

--- a/db/migrate/20210108102934_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210108102934_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20210108102934_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210108102934_create_active_storage_tables.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change
@@ -11,7 +13,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.string   :checksum,     null: false
       t.datetime :created_at,   null: false
 
-      t.index [ :key ], unique: true
+      t.index [:key], unique: true
     end
 
     create_table :active_storage_attachments do |t|
@@ -21,16 +23,18 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
       t.datetime :created_at, null: false
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.index %i[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness', unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
+    # rubocop:disable Rails/CreateTableWithTimestamps
     create_table :active_storage_variant_records do |t|
       t.belongs_to :blob, null: false, index: false
       t.string :variation_digest, null: false
 
-      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.index %i[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
+    # rubocop:enable Rails/CreateTableWithTimestamps
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,43 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_22_065204) do
+ActiveRecord::Schema.define(version: 2021_01_08_102934) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "books", force: :cascade do |t|
     t.string "title"
@@ -40,4 +68,6 @@ ActiveRecord::Schema.define(version: 2020_11_22_065204) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
## 目的
- FJORD BOOT CAMP 「ActiveStorage で画像アップロードを実装する」提出物
- ユーザーのアイコン画像アップロードの機能を追加

## やったこと
- ユーザのアイコン画像アップロード機能を追加
    - ユーザ詳細画面では`50*50`で、ユーザ一覧画面では`30*30`にリサイズして表示する
    - i18n対応済み（ロケールは日本語のみ）
- 追加要件：プロフィール編集画面にも現在設定されているアイコンを表示する
    - ユーザ詳細画面同様`50*50`にリサイズして表示する
- 追加要件：アップロードできるファイル形式は`PNG`、`JPG`、`GIF`のみとする
    - Gem：[active\_storage\_validations](https://github.com/igorkasyanchuk/active_storage_validations)を使用
    - エラーメッセージ：`アイコンには、JPG、PNG、GIFのいずれかを指定してください `

## UIに対する変更点
- ユーザ一覧画面
<img src="https://user-images.githubusercontent.com/61409641/104082800-5d51db00-527c-11eb-8777-6d67e495d854.png" width=700>

- ユーザ詳細画面
<img src="https://user-images.githubusercontent.com/61409641/104082786-3f847600-527c-11eb-8af1-a1f53e2c9052.png"  width=400>

- ユーザ編集画面（追加要件）。
![image](https://user-images.githubusercontent.com/61409641/104082815-7ce90380-527c-11eb-9e73-62ad0858d280.png)

## 申し送り事項
### Rubocop
- https://github.com/IkumaTadokoro/fjord-books_app/compare/06-user_icon...IkumaTadokoro:my-user_icon?expand=1#diff-9b32606f00305904d4f58d061029115af880493d2495b3911ab9ebe279350406R30
    - Rubocopにより、`Rails/CreateTableWithTimestamps`の警告が発生
    - 自動生成されたファイルであるため、`timestamp`の追加は不要と判断し、Rubocop対象外としました
    - 参考：[Configuration :: RuboCop Docs](https://docs.rubocop.org/rubocop/1.0/configuration.html#disabling-cops-within-source-code)
- 上記前提の元、Rubocop実行済
![image](https://user-images.githubusercontent.com/61409641/104082302-6e98e880-5278-11eb-8a5b-550e11c7492e.png)

### その他
- active_storage_validationについては、パーフェクトRubyOnRails p.233を参考に採択しました
> 5-2-7 validationヘルパーの不足
> Active Storage Validationsなどのgemを利用する必要があります。