### PR TITLE
日報機能とコメント機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
+gem 'active_decorator'
 gem 'carrierwave'
 gem 'devise'
 gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_decorator (1.3.4)
+      activesupport
     activejob (6.1.0)
       activesupport (= 6.1.0)
       globalid (>= 0.3.6)
@@ -312,6 +314,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_decorator
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,46 +1,11 @@
 # frozen_string_literal: true
 
-class Books::CommentsController < ApplicationController
-  before_action :set_book
-  before_action :set_comment, only: %i[edit update destroy]
-
-  def create
-    comment = @book.comments.new(comment_params)
-    comment.user = current_user
-
-    if comment.save
-      redirect_to @book, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
-    else
-      render :new
-    end
-  end
-
-  def edit; end
-
-  def update
-    if @comment.update(comment_params)
-      redirect_to @book, notice: t('controllers.common.notice_update', name: Report.model_name.human)
-    else
-      render :edit
-    end
-  end
-
-  def destroy
-    @comment.destroy
-    redirect_to @book, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
-  end
+class Books::CommentsController < CommentsController
+  before_action :set_commentable
 
   private
 
-  def set_book
-    @book = Book.find(params[:book_id])
-  end
-
-  def set_comment
-    @comment = Comment.find(params[:id])
-  end
-
-  def comment_params
-    params.require(:comment).permit(:contents)
+  def set_commentable
+    @commentable = Book.find(params[:book_id])
   end
 end

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Books::CommentsController < ApplicationController
+  def create
+    book = Book.find(params[:book_id])
+    comment = book.comments.new(comment_params)
+    comment.user = current_user
+
+    if comment.save
+      redirect_to book, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
+    else
+      render :new
+    end
+  end
+
+  def comment_params
+    params.require(:comment).permit(:contents)
+  end
+end

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,16 +1,29 @@
 # frozen_string_literal: true
 
 class Books::CommentsController < ApplicationController
+  before_action :set_book
+
   def create
-    book = Book.find(params[:book_id])
-    comment = book.comments.new(comment_params)
+    comment = @book.comments.new(comment_params)
     comment.user = current_user
 
     if comment.save
-      redirect_to book, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
+      redirect_to @book, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
     else
       render :new
     end
+  end
+
+  def destroy
+    comment = Comment.find(params[:id])
+    comment.destroy
+    redirect_to @book, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
+  end
+
+  private
+
+  def set_book
+    @book = Book.find(params[:book_id])
   end
 
   def comment_params

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -2,6 +2,7 @@
 
 class Books::CommentsController < ApplicationController
   before_action :set_book
+  before_action :set_comment, only: %i[edit update destroy]
 
   def create
     comment = @book.comments.new(comment_params)
@@ -14,9 +15,18 @@ class Books::CommentsController < ApplicationController
     end
   end
 
+  def edit; end
+
+  def update
+    if @comment.update(comment_params)
+      redirect_to @book, notice: t('controllers.common.notice_update', name: Report.model_name.human)
+    else
+      render :edit
+    end
+  end
+
   def destroy
-    comment = Comment.find(params[:id])
-    comment.destroy
+    @comment.destroy
     redirect_to @book, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
   end
 
@@ -24,6 +34,10 @@ class Books::CommentsController < ApplicationController
 
   def set_book
     @book = Book.find(params[:book_id])
+  end
+
+  def set_comment
+    @comment = Comment.find(params[:id])
   end
 
   def comment_params

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -3,72 +3,47 @@
 class BooksController < ApplicationController
   before_action :set_book, only: %i[show edit update destroy]
 
-  # GET /books
-  # GET /books.json
   def index
     @books = Book.order(:id).page(params[:page])
   end
 
-  # GET /books/1
-  # GET /books/1.json
   def show; end
 
-  # GET /books/new
   def new
     @book = Book.new
   end
 
-  # GET /books/1/edit
   def edit; end
 
-  # POST /books
-  # POST /books.json
   def create
     @book = Book.new(book_params)
 
-    respond_to do |format|
-      if @book.save
-        format.html { redirect_to @book, notice: t('controllers.common.notice_create', name: Book.model_name.human) }
-        format.json { render :show, status: :created, location: @book }
-      else
-        format.html { render :new }
-        format.json { render json: @book.errors, status: :unprocessable_entity }
-      end
+    if @book.save
+      redirect_to @book, notice: t('controllers.common.notice_create', name: Book.model_name.human)
+    else
+      render :new
     end
   end
 
-  # PATCH/PUT /books/1
-  # PATCH/PUT /books/1.json
   def update
-    respond_to do |format|
-      if @book.update(book_params)
-        format.html { redirect_to @book, notice: t('controllers.common.notice_update', name: Book.model_name.human) }
-        format.json { render :show, status: :ok, location: @book }
-      else
-        format.html { render :edit }
-        format.json { render json: @book.errors, status: :unprocessable_entity }
-      end
+    if @book.update(book_params)
+      redirect_to @book, notice: t('controllers.common.notice_update', name: Book.model_name.human)
+    else
+      render :edit
     end
   end
 
-  # DELETE /books/1
-  # DELETE /books/1.json
   def destroy
     @book.destroy
-    respond_to do |format|
-      format.html { redirect_to books_url, notice: t('controllers.common.notice_destroy', name: Book.model_name.human) }
-      format.json { head :no_content }
-    end
+    redirect_to books_url, notice: t('controllers.common.notice_destroy', name: Book.model_name.human)
   end
 
   private
 
-  # Use callbacks to share common setup or constraints between actions.
   def set_book
     @book = Book.find(params[:id])
   end
 
-  # Only allow a list of trusted parameters through.
   def book_params
     params.require(:book).permit(:title, :memo, :author, :picture)
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 class CommentsController < ApplicationController
   before_action :set_comment, only: %i[edit update destroy]
 
   def create
-    comment = @commentable.comments.new(comment_params)
-    comment.user = current_user
+    @comment = @commentable.comments.new(comment_params)
+    @comment.user = current_user
 
-    if comment.save
+    if @comment.save
       redirect_to @commentable, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
     else
-      # TODO:バリデーションエラー（必須項目なし）の場合のリダイレクト先
+      render :create
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,39 @@
+class CommentsController < ApplicationController
+  before_action :set_comment, only: %i[edit update destroy]
+
+  def create
+    comment = @commentable.comments.new(comment_params)
+    comment.user = current_user
+
+    if comment.save
+      redirect_to @commentable, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
+    else
+      # TODO:バリデーションエラー（必須項目なし）の場合のリダイレクト先
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @comment.update(comment_params)
+      redirect_to @commentable, notice: t('controllers.common.notice_update', name: Comment.model_name.human)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @comment.destroy
+    redirect_to @commentable, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
+  end
+
+  private
+
+  def set_comment
+    @comment = Comment.find(params[:id])
+  end
+
+  def comment_params
+    params.require(:comment).permit(:contents)
+  end
+end

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -2,6 +2,7 @@
 
 class Reports::CommentsController < ApplicationController
   before_action :set_report
+  before_action :set_comment, only: %i[edit update destroy]
 
   def create
     comment = @report.comments.new(comment_params)
@@ -14,9 +15,18 @@ class Reports::CommentsController < ApplicationController
     end
   end
 
+  def edit; end
+
+  def update
+    if @comment.update(comment_params)
+      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
+    else
+      render :edit
+    end
+  end
+
   def destroy
-    comment = Comment.find(params[:id])
-    comment.destroy
+    @comment.destroy
     redirect_to @report, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
   end
 
@@ -24,6 +34,10 @@ class Reports::CommentsController < ApplicationController
 
   def set_report
     @report = Report.find(params[:report_id])
+  end
+
+  def set_comment
+    @comment = Comment.find(params[:id])
   end
 
   def comment_params

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,46 +1,11 @@
 # frozen_string_literal: true
 
-class Reports::CommentsController < ApplicationController
-  before_action :set_report
-  before_action :set_comment, only: %i[edit update destroy]
-
-  def create
-    comment = @report.comments.new(comment_params)
-    comment.user = current_user
-
-    if comment.save
-      redirect_to @report, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
-    else
-      render :new
-    end
-  end
-
-  def edit; end
-
-  def update
-    if @comment.update(comment_params)
-      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
-    else
-      render :edit
-    end
-  end
-
-  def destroy
-    @comment.destroy
-    redirect_to @report, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
-  end
+class Reports::CommentsController < CommentsController
+  before_action :set_commentable
 
   private
 
-  def set_report
-    @report = Report.find(params[:report_id])
-  end
-
-  def set_comment
-    @comment = Comment.find(params[:id])
-  end
-
-  def comment_params
-    params.require(:comment).permit(:contents)
+  def set_commentable
+    @commentable = Report.find(params[:report_id])
   end
 end

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Reports::CommentsController < ApplicationController
+  def create
+    report = Report.find(params[:report_id])
+    comment = report.comments.new(comment_params)
+    comment.user = current_user
+
+    if comment.save
+      redirect_to report, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
+    else
+      render :new
+    end
+  end
+
+  def comment_params
+    params.require(:comment).permit(:contents)
+  end
+end

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,16 +1,29 @@
 # frozen_string_literal: true
 
 class Reports::CommentsController < ApplicationController
+  before_action :set_report
+
   def create
-    report = Report.find(params[:report_id])
-    comment = report.comments.new(comment_params)
+    comment = @report.comments.new(comment_params)
     comment.user = current_user
 
     if comment.save
-      redirect_to report, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
+      redirect_to @report, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
     else
       render :new
     end
+  end
+
+  def destroy
+    comment = Comment.find(params[:id])
+    comment.destroy
+    redirect_to @report, notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
+  end
+
+  private
+
+  def set_report
+    @report = Report.find(params[:report_id])
   end
 
   def comment_params

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class ReportsController < ApplicationController
+  before_action :set_report, only: %i[edit update destroy]
+
+  def index
+    @reports = Report.includes(:user).order(:id).page(params[:page])
+  end
+
+  def show
+    @report = Report.find(params[:id])
+  end
+
+  def new
+    @report = current_user.reports.new
+  end
+
+  def edit; end
+
+  def create
+    @report = current_user.reports.new(report_params)
+
+    if @report.save
+      redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @report.update(report_params)
+      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @report.destroy
+    redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
+  end
+
+  private
+
+  def set_report
+    @report = current_user.reports.find(params[:id])
+  end
+
+  def report_params
+    params.require(:report).permit(:title, :contents)
+  end
+end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module UserDecorator
+  def name_or_email
+    name.presence || email
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,6 @@
 
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
+
+  has_many :comments, as: :commentable, dependent: :destroy
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Comment < ApplicationRecord
+  belongs_to :commentable, polymorphic: true
+  belongs_to :user
+
+  validates :contents, presence: true
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,6 +2,7 @@
 
 class Report < ApplicationRecord
   belongs_to :user
+  has_many :comments, as: :commentable, dependent: :destroy
 
   validates :title, presence: true
   validates :contents, presence: true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Report < ApplicationRecord
+  belongs_to :user
+
+  validates :title, presence: true
+  validates :contents, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
   has_many :passive_relationships, class_name: 'Relationship', foreign_key: :following_id, dependent: :destroy, inverse_of: :following
   has_many :followers, through: :passive_relationships, source: :follower
 
+  has_many :reports, dependent: :destroy
+
   has_one_attached :avatar
 
   validates :uid, uniqueness: { scope: :provider }, if: -> { uid.present? }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   has_many :followers, through: :passive_relationships, source: :follower
 
   has_many :reports, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   has_one_attached :avatar
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,4 +42,8 @@ class User < ApplicationRecord
     relationship = active_relationships.find_by(following_id: user.id)
     relationship&.destroy!
   end
+
+  def name_or_email
+    name.presence || email
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,8 +42,4 @@ class User < ApplicationRecord
     relationship = active_relationships.find_by(following_id: user.id)
     relationship&.destroy!
   end
-
-  def name_or_email
-    name.presence || email
-  end
 end

--- a/app/views/books/_book.json.jbuilder
+++ b/app/views/books/_book.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! book, :id, :title, :memo, :created_at, :updated_at
-json.url book_url(book, format: :json)

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: book, local: true) do |form| %>
+<%= form_with(model: book) do |form| %>
   <% if book.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(book.errors.count, "error") %> prohibited this book from being saved:</h2>

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: book) do |form| %>
   <% if book.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(book.errors.count, "error") %> prohibited this book from being saved:</h2>
+      <h2><%= t('errors.template.header.other', model: Book.model_name.human, count: book.errors.count) %></h2>
 
       <ul>
         <% book.errors.full_messages.each do |message| %>

--- a/app/views/books/comments/edit.html.erb
+++ b/app/views/books/comments/edit.html.erb
@@ -1,0 +1,6 @@
+<h1><%= t('views.common.title_edit', name: Comment.model_name.human) %></h1>
+
+<%= form_with model: [@book, @comment], local: true do |f| %>
+  <%= f.text_field :contents, required: true %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/books/index.json.jbuilder
+++ b/app/views/books/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @books, partial: "books/book", as: :book

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -20,5 +20,7 @@
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
+<%= render 'shared/comment', commentable: @book %>
+
 <%= link_to t('views.common.edit'), edit_book_path(@book) %> |
 <%= link_to t('views.common.back'), books_path %>

--- a/app/views/books/show.json.jbuilder
+++ b/app/views/books/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "books/book", book: @book

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("errors").innerHTML = "<%= j render("shared/errors", errors: @comment.errors) %>"

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,6 +1,6 @@
 <h1><%= t('views.common.title_edit', name: Comment.model_name.human) %></h1>
 
-<%= form_with model: [@book, @comment], local: true do |f| %>
+<%= form_with model: [@commentable, @comment], local: true do |f| %>
   <%= f.text_field :contents, required: true %>
   <%= f.submit %>
 <% end %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,6 +1,6 @@
 <h1><%= t('views.common.title_edit', name: Comment.model_name.human) %></h1>
 
-<%= form_with model: [@commentable, @comment], local: true do |f| %>
+<%= form_with model: [@commentable, @comment] do |f| %>
   <%= f.text_field :contents, required: true %>
   <%= f.submit %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,9 @@
           <li>
             <%= link_to User.model_name.human, users_path %>
           </li>
+          <li>
+            <%= link_to Report.model_name.human, reports_path %>
+          </li>
         </ul>
         <div class="title"><%= t('.sign_in_as', email: current_user.email) %></div>
         <ul>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: report) do |form| %>
   <% if report.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(report.errors.count, "error") %> prohibited this report from being saved:</h2>
+      <h2><%= t('errors.template.header.other', model: Report.model_name.human, count: report.errors.count) %></h2>
 
       <ul>
         <% report.errors.each do |error| %>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: report) do |form| %>
+  <% if report.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(report.errors.count, "error") %> prohibited this report from being saved:</h2>
+
+      <ul>
+        <% report.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :contents %>
+    <%= form.text_area :contents %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/reports/comments/edit.html.erb
+++ b/app/views/reports/comments/edit.html.erb
@@ -1,0 +1,6 @@
+<h1><%= t('views.common.title_edit', name: Comment.model_name.human) %></h1>
+
+<%= form_with model: [@report, @comment], local: true do |f| %>
+  <%= f.text_field :contents, required: true %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/reports/comments/edit.html.erb
+++ b/app/views/reports/comments/edit.html.erb
@@ -1,6 +1,0 @@
-<h1><%= t('views.common.title_edit', name: Comment.model_name.human) %></h1>
-
-<%= form_with model: [@report, @comment], local: true do |f| %>
-  <%= f.text_field :contents, required: true %>
-  <%= f.submit %>
-<% end %>

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -1,0 +1,6 @@
+<h1><%= t('views.common.title_edit', name: Report.model_name.human) %></h1>
+
+<%= render 'form', report: @report %>
+
+<%= link_to t('views.common.show'), @report %> |
+<%= link_to t('views.common.back'), reports_path %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -16,7 +16,7 @@
       <tr>
         <td><%= report.title %></td>
         <td><%= report.contents %></td>
-        <td><%= report.user.name %></td>
+        <td><%= report.user.name_or_email %></td>
         <td><%= l report.created_at %></td>
         <td><%= link_to t('views.common.show'), report %></td>
         <% if report.user == current_user %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,0 +1,36 @@
+<h1><%= Report.model_name.human %></h1>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= Report.human_attribute_name(:title) %></th>
+      <th><%= Report.human_attribute_name(:contents) %></th>
+      <th><%= Report.human_attribute_name(:user) %></th>
+      <th><%= Report.human_attribute_name(:created_at) %></th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @reports.each do |report| %>
+      <tr>
+        <td><%= report.title %></td>
+        <td><%= report.contents %></td>
+        <td><%= report.user.name %></td>
+        <td><%= l report.created_at %></td>
+        <td><%= link_to t('views.common.show'), report %></td>
+        <% if report.user == current_user %>
+          <td><%= link_to t('views.common.edit'), edit_report_path(report) %></td>
+          <td><%= link_to t('views.common.destroy'), report, method: :delete, data: { confirm: t('views.common.delete_confirm') } %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @reports %>
+
+<br>
+
+<%= link_to t('views.common.new'), new_report_path %>
+

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t('views.common.title_new', name: Report.model_name.human) %></h1>
+
+<%= render 'form', report: @report %>
+
+<%= link_to t('views.common.back'), reports_path %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,0 +1,26 @@
+<h1><%= t('views.common.title_show', name: Report.model_name.human) %></h1>
+
+<p>
+  <strong><%= Report.human_attribute_name(:title) %>:</strong>
+  <%= @report.title %>
+</p>
+
+<p>
+  <strong><%= Report.human_attribute_name(:contents) %>:</strong>
+  <%= @report.contents %>
+</p>
+
+<p>
+  <strong><%= Report.human_attribute_name(:user) %>:</strong>
+  <%= @report.user.name %>
+</p>
+
+<p>
+  <strong><%= Report.human_attribute_name(:created_at) %>:</strong>
+  <%= l @report.created_at %>
+</p>
+
+<% if @report.user == current_user %>
+  <%= link_to t('views.common.edit'), edit_report_path(@report) %> |
+<% end %>
+<%= link_to t('views.common.back'), reports_path %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -12,7 +12,7 @@
 
 <p>
   <strong><%= Report.human_attribute_name(:user) %>:</strong>
-  <%= @report.user.name %>
+  <%= @report.user.name_or_email %>
 </p>
 
 <p>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -20,6 +20,8 @@
   <%= l @report.created_at %>
 </p>
 
+<%= render 'shared/comment', commentable: @report %>
+
 <% if @report.user == current_user %>
   <%= link_to t('views.common.edit'), edit_report_path(@report) %> |
 <% end %>

--- a/app/views/shared/_comment.erb
+++ b/app/views/shared/_comment.erb
@@ -17,7 +17,8 @@
 <% else %>
   <%= 'まだコメントは投稿されていません' %>
 <% end %>
-  <%= form_with model: [commentable, commentable.comments.new], local: true do |f| %>
+<%= form_with model: [commentable, commentable.comments.new], local: false do |f| %>
+  <div id="errors"></div>
   <%= f.text_field :contents, required: true %>
-  <%= f.submit %>
+  <%= f.submit t('.create') %>
 <% end %>

--- a/app/views/shared/_comment.erb
+++ b/app/views/shared/_comment.erb
@@ -15,7 +15,7 @@
     <% end %>
   </ul>
 <% else %>
-  <%= 'まだコメントは投稿されていません' %>
+  <%= t('.empty') %>
 <% end %>
 <%= form_with model: [commentable, commentable.comments.new], local: false do |f| %>
   <div id="errors"></div>

--- a/app/views/shared/_comment.erb
+++ b/app/views/shared/_comment.erb
@@ -1,0 +1,19 @@
+<h2><%= Comment.model_name.human %></h2>
+
+<% if commentable.comments.present? %>
+  <ul>
+    <% commentable.comments.includes(:user).each do |comment| %>
+      <li>
+        <%= comment.contents %>
+        <%= comment.user.name_or_email %>
+        <%= l comment.created_at %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <%= 'まだコメントは投稿されていません' %>
+<% end %>
+  <%= form_with model: [commentable, commentable.comments.new], local: true do |f| %>
+  <%= f.text_field :contents, required: true %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/shared/_comment.erb
+++ b/app/views/shared/_comment.erb
@@ -7,6 +7,9 @@
         <%= comment.contents %>
         <%= comment.user.name_or_email %>
         <%= l comment.created_at %>
+        <% if comment.user == current_user %>
+          <%= link_to t('views.common.destroy'), [commentable, comment], method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
+        <% end %>
       </li>
     <% end %>
   </ul>

--- a/app/views/shared/_comment.erb
+++ b/app/views/shared/_comment.erb
@@ -8,6 +8,7 @@
         <%= comment.user.name_or_email %>
         <%= l comment.created_at %>
         <% if comment.user == current_user %>
+          <%= link_to t('views.common.edit'), [:edit, commentable, comment] %>
           <%= link_to t('views.common.destroy'), [commentable, comment], method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
         <% end %>
       </li>

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,5 +1,5 @@
 <div id="error_explanation">
-  <h2><%= pluralize(errors.count, "error") %> prohibited this comment from being saved:</h2>
+  <h2><%= t('errors.template.header.other', model: Comment.model_name.human, count: errors.count) %></h2>
 
   <ul>
     <% errors.full_messages.each do |message| %>

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,0 +1,9 @@
+<div id="error_explanation">
+  <h2><%= pluralize(errors.count, "error") %> prohibited this comment from being saved:</h2>
+
+  <ul>
+    <% errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -39,11 +39,11 @@
 </ul>
 
 <% if current_user.following?(@user) %>
-  <%= form_with(url: user_relationships_path(@user), method: :delete, local: true) do |f| %>
+  <%= form_with(url: user_relationships_path(@user), method: :delete) do |f| %>
     <%= f.submit t('.destroy') %>
   <% end %>
 <% elsif current_user != @user %>
-  <%= form_with(url: user_relationships_path(@user), local: true) do |f| %>
+  <%= form_with(url: user_relationships_path(@user)) do |f| %>
     <%= f.submit t('.create') %>
   <% end %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module BooksApp
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Asia/Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -201,7 +201,7 @@ ja:
   time:
     am: 午前
     formats:
-      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      default: "%Y年%m月%d日(%a) %H時%M分"
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -228,6 +228,9 @@ ja:
     application:
       menu: メニュー
       sign_in_as: "%{email} としてログイン中"
+  shared:
+    comment:
+      create: コメントする
   users:
     show:
       followings: "%{count} フォロー"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -137,7 +137,7 @@ ja:
       body: 次の項目を確認してください
       header:
         one: "%{model}にエラーが発生しました"
-        other: "%{model}に%{count}個のエラーが発生しました"
+        other: "%{count}個のエラーがあるため、%{model}を保存出来ません。"
   helpers:
     select:
       prompt: 選択してください
@@ -231,6 +231,7 @@ ja:
   shared:
     comment:
       create: コメントする
+      empty: まだコメントは投稿されていません
   users:
     show:
       followings: "%{count} フォロー"

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       book: 本  #g
       report: 日報
+      comment: コメント
     attributes:
       book:
         author: 著者  #g
@@ -20,3 +21,4 @@ ja:
         contents: 本文
         user: 作成者
         created_at: 投稿日時
+

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -2,7 +2,7 @@ ja:
   activerecord:
     models:
       book: 本  #g
-
+      report: 日報
     attributes:
       book:
         author: 著者  #g
@@ -15,3 +15,8 @@ ja:
         address: 住所
         self_introduction: 自己紹介文
         avatar: ユーザ画像
+      report:
+        title: タイトル
+        contents: 本文
+        user: 作成者
+        created_at: 投稿日時

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -21,4 +21,6 @@ ja:
         contents: 本文
         user: 作成者
         created_at: 投稿日時
+      comment:
+        contents: コメント
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks', registrations: "users/registrations" }
   root to: 'books#index'
   resources :books
+  resources :reports
   resources :users, only: %i[index show] do
     resource :relationships, only: %i[create destroy]
     scope module: :users do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,12 +4,12 @@ Rails.application.routes.draw do
   root to: 'books#index'
   resources :books do
     scope module: :books do
-      resources :comments, only: [:create]
+      resources :comments, only: %i[create destroy]
     end
   end
   resources :reports do
     scope module: :reports do
-      resources :comments, only: [:create]
+      resources :comments, only: %i[create destroy]
     end
   end
   resources :users, only: %i[index show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,14 +2,19 @@ Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks', registrations: "users/registrations" }
   root to: 'books#index'
+
+  concern :commentable do
+    resources :comments, only: %i[create edit update destroy]
+  end
+
   resources :books do
     scope module: :books do
-      resources :comments, only: %i[create edit update destroy]
+      concerns :commentable
     end
   end
   resources :reports do
     scope module: :reports do
-      resources :comments, only: %i[create edit update destroy]
+      concerns :commentable
     end
   end
   resources :users, only: %i[index show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks', registrations: "users/registrations" }
   root to: 'books#index'
   resources :books
-  resources :reports
+  resources :reports do
+    scope module: :reports do
+      resources :comments, only: [:create]
+    end
+  end
   resources :users, only: %i[index show] do
     resource :relationships, only: %i[create destroy]
     scope module: :users do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@ Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks', registrations: "users/registrations" }
   root to: 'books#index'
-  resources :books
+  resources :books do
+    scope module: :books do
+      resources :comments, only: [:create]
+    end
+  end
   resources :reports do
     scope module: :reports do
       resources :comments, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,12 +4,12 @@ Rails.application.routes.draw do
   root to: 'books#index'
   resources :books do
     scope module: :books do
-      resources :comments, only: %i[create destroy]
+      resources :comments, only: %i[create edit update destroy]
     end
   end
   resources :reports do
     scope module: :reports do
-      resources :comments, only: %i[create destroy]
+      resources :comments, only: %i[create edit update destroy]
     end
   end
   resources :users, only: %i[index show] do

--- a/db/migrate/20210117071550_create_reports.rb
+++ b/db/migrate/20210117071550_create_reports.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateReports < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reports do |t|
+      t.string :title, null: false
+      t.text :contents, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210121111901_create_comments.rb
+++ b/db/migrate/20210121111901_create_comments.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.references :commentable, polymorphic: true, null: false
+      t.references :user, null: false, foreign_key: true
+      t.string :contents, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_17_071550) do
+ActiveRecord::Schema.define(version: 2021_01_21_111901) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -47,6 +47,17 @@ ActiveRecord::Schema.define(version: 2021_01_17_071550) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "author"
     t.string "picture"
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.string "commentable_type", null: false
+    t.integer "commentable_id", null: false
+    t.integer "user_id", null: false
+    t.string "contents", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "relationships", force: :cascade do |t|
@@ -88,5 +99,6 @@ ActiveRecord::Schema.define(version: 2021_01_17_071550) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "users"
   add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_27_052521) do
+ActiveRecord::Schema.define(version: 2021_01_17_071550) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -58,6 +58,15 @@ ActiveRecord::Schema.define(version: 2020_12_27_052521) do
     t.index ["following_id"], name: "index_relationships_on_following_id"
   end
 
+  create_table "reports", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "contents", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_reports_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -79,4 +88,5 @@ ActiveRecord::Schema.define(version: 2020_12_27_052521) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "reports", "users"
 end


### PR DESCRIPTION
## 目的
- FJORD BOOT CAMP「コメントを付けられるようにする」課題提出物
- 日報機能を実装する
- コメント機能を実装する

## やったこと
- 日報（reports）のCRUDを実装
    - 入力項目はタイトルと本文。いずれも必須項目とする
    - 日報を更新・削除できるのはその日報を投稿した本人のみ
    - ユーザが退会した場合、そのユーザの日報は削除される
- 本とレポートの各詳細画面からコメントを投稿できるようにする
    - 本もしくは日報が削除された場合、それに紐づくコメントは削除される
    - ユーザが退会した場合、そのユーザのコメントは削除される
- 表示上のタイムゾーンをAsia/Tokyoに変更
    - 合わせてロケールファイルの時刻表示の秒部分を修正
- （歓迎要件）HTML5の必須チェックが効かない場合を考慮し、バリデーションエラー時のレスポンスも返せるように実装
    - SJRで実装
- （歓迎要件）コメントが1件もない場合はその旨を画面に表示する
- （歓迎要件）コメントの編集と削除ができるようにする

## スクリーンショット

- 本の詳細画面（コメント投稿）

![image](https://user-images.githubusercontent.com/61409641/105624083-3e4d6e80-5e62-11eb-9e7a-3820caa3aa9d.png)

- 日報の詳細画面（コメント投稿）

![image](https://user-images.githubusercontent.com/61409641/105624084-43122280-5e62-11eb-90d4-e1d45452d01a.png)

## 申し送り事項
- 本PRとは直接関係ありませんが、既存ソースの以下の点を修正しています。
    - booksのJSONレスポンス用に用意されている部分を削除（HTML前提のため）
    - `form_with`の`local: true`オプションを削除（Rails6.1からはこちらがデフォルトになるため）
- Rubocop実行済

![image](https://user-images.githubusercontent.com/61409641/105623495-7605e780-5e5d-11eb-83d1-ef63557f49c4.png)
